### PR TITLE
FIX: Empty credit role crash

### DIFF
--- a/metron_talker/metron.py
+++ b/metron_talker/metron.py
@@ -584,8 +584,10 @@ class MetronTalker(ComicTalker):
         if hasattr(issue, "credits"):
             for person in issue.credits:
                 person_name = getattr(person, "creator", "")
-                role = person.role[0].name if person.role and person.role[0] else ""
-                md.add_credit(person_name, role, False)
+                # A person is not required to have a role, metron returns an empty list
+                roles = [role.name for name in person.role] if person.role or [""]
+                for role in roles:
+                    md.add_credit(person_name, role.name, False)
 
         md.volume = utils.xlate_int(issue.series.volume)
         if self.use_series_start_as_volume:

--- a/metron_talker/metron.py
+++ b/metron_talker/metron.py
@@ -583,7 +583,9 @@ class MetronTalker(ComicTalker):
 
         if hasattr(issue, "credits"):
             for person in issue.credits:
-                md.add_credit(person.creator, person.role[0].name.title().strip(), False)
+                person_name = getattr(person, "creator", "")
+                role = person.role[0].name if person.role and person.role[0] else ""
+                md.add_credit(person_name, role, False)
 
         md.volume = utils.xlate_int(issue.series.volume)
         if self.use_series_start_as_volume:

--- a/metron_talker/metron.py
+++ b/metron_talker/metron.py
@@ -585,9 +585,9 @@ class MetronTalker(ComicTalker):
             for person in issue.credits:
                 person_name = getattr(person, "creator", "")
                 # A person is not required to have a role, metron returns an empty list
-                roles = [role.name for name in person.role] if person.role or [""]
+                roles = [role.name for role in person.role] if person.role else [""]
                 for role in roles:
-                    md.add_credit(person_name, role.name, False)
+                    md.add_credit(person_name, role, False)
 
         md.volume = utils.xlate_int(issue.series.volume)
         if self.use_series_start_as_volume:


### PR DESCRIPTION
An empty credit role caused a crash. Check both name and role. Fixes #43